### PR TITLE
Upgraded to .NET 4.6.1, fixed initial load

### DIFF
--- a/FFXIVAPP.Plugin.GathererTimer.sln
+++ b/FFXIVAPP.Plugin.GathererTimer.sln
@@ -14,12 +14,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{BF2380
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A5FC9B05-33BB-4169-8881-573549414A17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5FC9B05-33BB-4169-8881-573549414A17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5FC9B05-33BB-4169-8881-573549414A17}.Debug|x86.ActiveCfg = Debug|x86
 		{A5FC9B05-33BB-4169-8881-573549414A17}.Debug|x86.Build.0 = Debug|x86
+		{A5FC9B05-33BB-4169-8881-573549414A17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5FC9B05-33BB-4169-8881-573549414A17}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A5FC9B05-33BB-4169-8881-573549414A17}.Release|x86.ActiveCfg = Release|x86
 		{A5FC9B05-33BB-4169-8881-573549414A17}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/FFXIVAPP.Plugin.GathererTimer/FFXIVAPP.Plugin.GathererTimer.csproj
+++ b/FFXIVAPP.Plugin.GathererTimer/FFXIVAPP.Plugin.GathererTimer.csproj
@@ -49,10 +49,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\distribution\FFXIVAPP.Localization.dll</HintPath>
     </Reference>
-    <Reference Include="FFXIVAPP.Plugin.GathererTimer, Version=1.0.5593.14333, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\distribution\FFXIVAPP.Plugin.GathererTimer.dll</HintPath>
-    </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.9.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\distribution\HtmlAgilityPack.dll</HintPath>

--- a/FFXIVAPP.Plugin.GathererTimer/FFXIVAPP.Plugin.GathererTimer.csproj
+++ b/FFXIVAPP.Plugin.GathererTimer/FFXIVAPP.Plugin.GathererTimer.csproj
@@ -36,18 +36,32 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FFXIVAPP.Common, Version=2.0.5500.34492, Culture=neutral, processorArchitecture=x86">
+    <Reference Include="FFXIVAPP.Common, Version=2.0.5673.14245, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\distribution\FFXIVAPP.Common.dll</HintPath>
     </Reference>
-    <Reference Include="FFXIVAPP.IPluginInterface, Version=2.0.5500.34587, Culture=neutral, processorArchitecture=x86">
+    <Reference Include="FFXIVAPP.IPluginInterface, Version=2.0.5673.14263, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\distribution\FFXIVAPP.IPluginInterface.dll</HintPath>
-    </Reference>
-    <Reference Include="FFXIVAPP.Localization, Version=1.0.5500.34598, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\distribution\FFXIVAPP.Localization.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.9.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -57,12 +71,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\distribution\Ionic.Zip.dll</HintPath>
     </Reference>
-    <Reference Include="MahApps.Metro, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MahApps.Metro, Version=1.1.2.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\distribution\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NAudio, Version=1.7.1.17, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NAudio, Version=1.7.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\distribution\NAudio.dll</HintPath>
     </Reference>
@@ -70,7 +84,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\distribution\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=3.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\distribution\NLog.dll</HintPath>
     </Reference>
@@ -372,7 +386,9 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y C:\dev\github\ffxivapp-plugin-gatherer-timer_master\build\Debug\FFXIVAPP.Plugin.GathererTimer.dll C:\dev\github\ffxivapp\build\Debug\Plugins\FFXIVAPP.Plugin.GathererTimer\FFXIVAPP.Plugin.GathererTimer.dll</PostBuildEvent>
+    <PostBuildEvent>copy /Y C:\dev\github\ffxivapp-plugin-gatherer-timer_master\FFXIVAPP.Plugin.GathererTimer\bin\Release\FFXIVAPP.Plugin.GathererTimer.dll C:\dev\github\ffxivapp\FFXIVAPP.Client\bin\Debug\Plugins\FFXIVAPP.Plugin.GathererTimer\FFXIVAPP.Plugin.GathererTimer.dll
+copy /Y C:\dev\github\ffxivapp-plugin-gatherer-timer_master\FFXIVAPP.Plugin.GathererTimer\bin\Release\FFXIVAPP.Plugin.GathererTimer.dll C:\dev\github\ffxivapp-plugin-gatherer-timer_master\distribution\FFXIVAPP.Plugin.GathererTimer.dll
+</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/distribution/VERSION.json
+++ b/distribution/VERSION.json
@@ -1,7 +1,7 @@
 {
     "PluginInfo": {
         "Name": "FFXIVAPP.Plugin.GathererTimer",
-        "Version": "1.0.5664.17426",
+        "Version": "1.0.5669.33352",
         "Files": [
             {
                 "Name": "FFXIVAPP.Plugin.GathererTimer.dll",

--- a/distribution/VERSION.json
+++ b/distribution/VERSION.json
@@ -1,7 +1,7 @@
 {
     "PluginInfo": {
         "Name": "FFXIVAPP.Plugin.GathererTimer",
-        "Version": "1.0.5669.33352",
+        "Version": "1.0.5674.34335",
         "Files": [
             {
                 "Name": "FFXIVAPP.Plugin.GathererTimer.dll",


### PR DESCRIPTION
- Local testing seems to indicate that this fixes an issue preventing the plugin from running-- there was a Dictionary KeyNotFoundException being thrown that went away once I upgraded and rebuilt.
- Doesn't address the fact that the XML file in this plugin is most certainly out of date and lacking any updated Heavensward content or the new content from Stormblood.